### PR TITLE
LIBFCREPO-481. Filter out unwanted triples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/pry
 bin/rake
 bin/warble
 *.jar
+*.pom

--- a/bin/fcrepo-audit-import.rb
+++ b/bin/fcrepo-audit-import.rb
@@ -10,8 +10,8 @@ class FileNotFound < StandardError; end
 # Our default values
 hostname = Socket.gethostname.chomp
 source_url = "https://#{hostname}/fcrepo/rest/audit"
-target_url = "https://#{hostname}/fuseki/fcrepo-audit/data"
-keystore = "/apps/fedora/ssl/backup-client.p12" 
+target_url = "https://#{hostname}/fuseki/testing/data"
+keystore = "/apps/fedora/ssl/backup-client.p12"
 password = "changeme"
 threads = 5
 
@@ -32,7 +32,7 @@ begin
   print Rainbow("Enter java keystore file path").white.bg(:red) + "  " + Rainbow("[#{keystore}] > ").cyan.blink
   input = gets.chomp
   _ks = input.length > 0 ? input : keystore
-  raise FileNotFound unless File.exists?(_ks) 
+  raise FileNotFound unless File.exists?(_ks)
 rescue FileNotFound
   puts Rainbow("File #{_ks} not found. Please try again").red
   retry
@@ -50,15 +50,15 @@ threads = input.to_i if input.length > 0
 
 begin
 
-  AuditResponseHandler.threads= threads 
+  AuditResponseHandler.threads= threads
   FCKeyStore.initialize_keystore( keystore, password  )
 
-  RDFMigrator.set_target(target_url)  
-  
+  RDFMigrator.set_target(target_url)
+
   FCClient.instance.start
 
   uris_request = HttpAsyncMethods.create_get(source_url)
-  response = FCClient.instance.client.execute(uris_request, AuditResponseHandler.new, nil)  
+  response = FCClient.instance.client.execute(uris_request, AuditResponseHandler.new, nil)
   queue = response.get
   while ( queue.size > 0 )
     sleep 5

--- a/bin/fcrepo-audit-import.rb
+++ b/bin/fcrepo-audit-import.rb
@@ -5,8 +5,6 @@ require 'main'
 
 class FileNotFound < StandardError; end
 
-
-
 # Our default values
 hostname = Socket.gethostname.chomp
 source_url = "https://#{hostname}/fcrepo/rest/audit"
@@ -15,41 +13,42 @@ keystore = "/apps/fedora/ssl/backup-client.p12"
 password = "changeme"
 threads = 5
 
-puts Rainbow("*" * 100 ).red
-puts Rainbow("*" * 100 ).red
-puts Rainbow("*" * 100 ).red
+if File.new("/dev/stdin").isatty
+  # if STDIN is a terminal, present prompts
+  # otherwise, use defaults
+  puts Rainbow("*" * 100 ).red
+  puts Rainbow("*" * 100 ).red
+  puts Rainbow("*" * 100 ).red
 
-print Rainbow("Enter source URL").white.bg(:red) + "  " + Rainbow("[#{source_url}] > ").cyan
-input = gets.chomp
-source_url = input if input.length > 0
-
-print Rainbow("Enter target URL").white.bg(:red) + "  " + Rainbow("[#{target_url}] > ").cyan
-input = gets.chomp
-target_url = input if input.length > 0
-
-
-begin
-  print Rainbow("Enter java keystore file path").white.bg(:red) + "  " + Rainbow("[#{keystore}] > ").cyan.blink
+  print Rainbow("Enter source URL").white.bg(:red) + "  " + Rainbow("[#{source_url}] > ").cyan
   input = gets.chomp
-  _ks = input.length > 0 ? input : keystore
-  raise FileNotFound unless File.exists?(_ks)
-rescue FileNotFound
-  puts Rainbow("File #{_ks} not found. Please try again").red
-  retry
+  source_url = input if input.length > 0
+
+  print Rainbow("Enter target URL").white.bg(:red) + "  " + Rainbow("[#{target_url}] > ").cyan
+  input = gets.chomp
+  target_url = input if input.length > 0
+
+  begin
+    print Rainbow("Enter java keystore file path").white.bg(:red) + "  " + Rainbow("[#{keystore}] > ").cyan.blink
+    input = gets.chomp
+    _ks = input.length > 0 ? input : keystore
+    raise FileNotFound unless File.exists?(_ks)
+  rescue FileNotFound
+    puts Rainbow("File #{_ks} not found. Please try again").red
+    retry
+  end
+  keystore = _ks
+
+  print Rainbow("Enter keystore password").white.bg(:red) + "  " + Rainbow("[#{password}] > ").cyan
+  input = gets.chomp
+  password = input if input.length > 0
+
+  print Rainbow("Enter number of threads to run").white.bg(:red) + "  " + Rainbow("[#{threads.to_s}] > ").cyan
+  input = gets.chomp
+  threads = input.to_i if input.length > 0
 end
-keystore = _ks
-
-print Rainbow("Enter keystore password").white.bg(:red) + "  " + Rainbow("[#{password}] > ").cyan
-input = gets.chomp
-password = input if input.length > 0
-
-print Rainbow("Enter number of threads to run").white.bg(:red) + "  " + Rainbow("[#{threads.to_s}] > ").cyan
-input = gets.chomp
-threads = input.to_i if input.length > 0
-
 
 begin
-
   AuditResponseHandler.threads= threads
   FCKeyStore.initialize_keystore( keystore, password  )
 

--- a/lib/main.rb
+++ b/lib/main.rb
@@ -3,13 +3,11 @@ require 'singleton'
 require 'thread'
 
 
-Dir.glob(File.join(__dir__, "http*.jar")).each { |f| require f }
-Dir.glob(File.join(__dir__, "slf4*.jar")).each { |f| require f }
-Dir.glob(File.join(__dir__, "commons-logging*.jar")).each { |f| require f }
-
+Dir.glob(File.join(__dir__, "*.jar")).each { |f| require f }
 
 java_import java.lang.System
 java_import java.io.FileInputStream
+java_import java.io.ByteArrayOutputStream
 java_import java.io.IOException
 java_import java.nio.CharBuffer
 java_import java.security.KeyStore
@@ -34,6 +32,9 @@ java_import org.apache.http.message.BasicHeader
 
 java_import java.util.concurrent.LinkedBlockingQueue
 
+java_import org.apache.jena.rdf.model.ModelFactory
+java_import org.apache.http.entity.ByteArrayEntity
+java_import org.apache.http.entity.ContentType
 
 class FCKeyStore
   include Singleton
@@ -50,10 +51,10 @@ class FCKeyStore
 
     @@keystore = KeyStore.get_instance("JKS")
     @@password = password.to_java.to_char_array
-    
+
     ios = FileInputStream.new(keystore_file)
     begin
-      @@keystore.load(ios, @@password) 
+      @@keystore.load(ios, @@password)
     ensure
       ios.close
     end
@@ -66,10 +67,10 @@ class FCClient
   attr_accessor :client
 
   def initialize
-    keystore = FCKeyStore.instance  
+    keystore = FCKeyStore.instance
     sslcontext = SSLContexts.custom.load_trust_material(nil, TrustSelfSignedStrategy.new).load_key_material(keystore.keystore, keystore.password).build
 
-    headers = [ 
+    headers = [
       BasicHeader.new("Accept", "application/n-triples"),
     ]
 
@@ -95,7 +96,11 @@ class RDFMigrator
   attr_accessor :name
 
   @@target = "https://localhost:/fuseki/fcrepo-audit/data"
-  
+
+  FEDORA_PREFIX = "http://fedora.info/definitions/v4/repository#"
+  LDP_PREFIX = "http://www.w3.org/ns/ldp#"
+  RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+
   def initialize( queue, name )
     @queue = queue
     @name = name
@@ -106,33 +111,61 @@ class RDFMigrator
   end
 
   def run
-    puts "starting worker #{@name}" 
-    while ( uri = @queue.poll(10000, java.util.concurrent.TimeUnit::MILLISECONDS); uri != "DONE" ) 
-      print "." 
-      begin 
+    puts "starting worker #{@name}"
+    while ( uri = @queue.poll(10000, java.util.concurrent.TimeUnit::MILLISECONDS); uri != "DONE" )
+      print "."
+      begin
         request = HttpGet.new(uri)
-        future = FCClient.instance.client.execute(request, nil)  
+        future = FCClient.instance.client.execute(request, nil)
         response = future.get
-        
+
+        model = ModelFactory.createDefaultModel
+        filteredModel = ModelFactory.createDefaultModel
+        model.read(response.getEntity.getContent, nil, 'N-TRIPLES')
+        statements = model.listStatements
+        while statements.hasNext
+          statement = statements.nextStatement
+          if filter(statement)
+            filteredModel.add(statement)
+          end
+        end
+        filteredStream = ByteArrayOutputStream.new
+        filteredModel.write(filteredStream, 'N-TRIPLES')
+
         post = HttpPost.new(target)
-        post.set_entity( response.get_entity )  
-        
-        future = FCClient.instance.client.execute(post, nil)  
+        post.set_entity(ByteArrayEntity.new(filteredStream.toByteArray, ContentType.create("application/n-triples")))
+
+        future = FCClient.instance.client.execute(post, nil)
         status = future.get.get_status_line
         case status.status_code
-        when 200...399 
-          print "+" 
+        when 200...399
+          print "+"
         else
           "Problem migrating #{uri}. Received #{status}"
         end
-        #puts EntityUtils.toString(future.get.get_entity) 
+        #puts EntityUtils.toString(future.get.get_entity)
       rescue => e
         puts "ERROR with #{uri} : #{e.message}"
         raise e
       end
-    end 
+    end
   end
-  
+
+  def filter(statement)
+    p = statement.getPredicate
+    if p.getURI.start_with?(FEDORA_PREFIX)
+      # skip it!
+      return false
+    elsif p.getURI == RDF_TYPE
+      o = statement.getResource
+      if o.getURI.start_with?(FEDORA_PREFIX) || o.getURI.start_with?(LDP_PREFIX)
+        # skip it!
+        return false
+      end
+    end
+    return true
+  end
+
   def self.set_target(target)
     @@target = target
   end
@@ -142,25 +175,25 @@ end
 
 class Forbidden < StandardError; end
 class AuditResponseHandler <  AsyncCharConsumer
-  
+
   attr_accessor :accumulator
-  attr_accessor :queue 
+  attr_accessor :queue
   attr_accessor :exception
 
   @@threads = 5
 
   def onCharReceived( buf, ioctrl)
-    if ( !@accumulator.nil? ) 
-      # convert to a string block 
-      output = @accumulator + java.lang.StringBuilder.new(buf).to_s 
-      lines = output.lines 
+    if ( !@accumulator.nil? )
+      # convert to a string block
+      output = @accumulator + java.lang.StringBuilder.new(buf).to_s
+      lines = output.lines
 
-      # we're getting in chunks, so don't assume last line to complete... 
+      # we're getting in chunks, so don't assume last line to complete...
       @accumulator = lines.pop
-       
+
       lines.select { |line| line.include?("<http://www.w3.org/ns/ldp#contains>") }
         .map { |line| line.split[2].gsub(/\<|\>/, '') }.each { |uri| @queue.offer uri }
-    end 
+    end
   end
 
   def onResponseReceived( response )
@@ -168,9 +201,9 @@ class AuditResponseHandler <  AsyncCharConsumer
     puts "Received response : #{status}"
 
     case status.status_code
-    when 200...399 
+    when 200...399
       @accumulator = ""
-      @queue = LinkedBlockingQueue.new 
+      @queue = LinkedBlockingQueue.new
       @@threads.times { |x| Thread.new { RDFMigrator.new(@queue, x.to_s).run } }
     else
       @exception = Forbidden.new "There is a problem. Received #{status}"
@@ -183,10 +216,10 @@ class AuditResponseHandler <  AsyncCharConsumer
   def buildResult(context)
     if ( !@exception.nil?  )
       raise @exception
-    else 
-      puts "Finished with URIS!!" 
+    else
+      puts "Finished with URIS!!"
       @@threads.times { @queue.offer("DONE")  }
-      return @queue 
+      return @queue
     end
   end
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,16 @@
   <name>FusekiMigrator</name>
   <url>http://maven.apache.org</url>
   <dependencies>
-    <dependency><groupId>org.apache.httpcomponents</groupId><artifactId>httpasyncclient</artifactId><version>4.1.3</version></dependency> 
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+      <version>4.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>apache-jena-libs</artifactId>
+      <type>pom</type>
+      <version>3.6.0</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Use Apache JENA to inspect the source graphs and filter out triples with fedora: predicates, or rdf:type statements with fedora: or ldp: types. This will produce an output graph that resembles those produced by the fcrepo-audit-triplestore route, without Fedora or LDP artifacts.

https://issues.umd.edu/browse/LIBFCREPO-481