### PR TITLE
LIBFCREPO-488. Modified standard in TTY detection.

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+fcrepo-audit-import

--- a/bin/fcrepo-audit-import.rb
+++ b/bin/fcrepo-audit-import.rb
@@ -13,7 +13,7 @@ keystore = "/apps/fedora/ssl/backup-client.p12"
 password = "changeme"
 threads = 5
 
-if File.new("/dev/stdin").isatty
+if STDIN.isatty
   # if STDIN is a terminal, present prompts
   # otherwise, use defaults
   puts Rainbow("*" * 100 ).red


### PR DESCRIPTION
Using File.new("/dev/stdin").isatty was failing on the fcrepo production
server due to permission issues on the /dev/stdin file.

Switching to STDIN.isatty should not run the same permission issues.

Also, following standard Ruby project layout, added a ".ruby-gemset" file
with the name of the project.

https://issues.umd.edu/browse/LIBFCREPO-488